### PR TITLE
SPで左のナビが一瞬表示されるのを修正した

### DIFF
--- a/src/templates/index.tsx
+++ b/src/templates/index.tsx
@@ -49,7 +49,9 @@ const Main = styled.main`
 `;
 
 const BaseLayout: React.FC = ({ children }) => {
-  const isMobile = useMediaQuery(`(max-width:${theme.breakpoints.sm})`);
+  const isMobile = useMediaQuery(`(max-width:${theme.breakpoints.sm})`, {
+    noSsr: true,
+  });
 
   return isMobile ? (
     <SpRoot>


### PR DESCRIPTION
fix #61 

https://material-ui.com/components/use-media-query/#usemediaquery-query-options-matches

一瞬表示されちゃっていたのはSSRのために `defaultMatches` が返ってきてしまうからぽいです 