### PR TITLE
Add missing node package fallback

### DIFF
--- a/esbuild/config.js
+++ b/esbuild/config.js
@@ -4,6 +4,8 @@ const path = require('path');
 const resolve = {
   name: 'resolve',
   setup(build) {
+    // Add custom resolve rules for packages that break building.
+    // These packages have the browser field in package.json, but it doesn't actually support the browser environment.
     build.onResolve({ filter: /^nanoid$/ }, () => {
       return {
         path: path.join(__dirname, '../node_modules/nanoid/index.browser.js'),
@@ -12,6 +14,14 @@ const resolve = {
     build.onResolve({ filter: /^cbor$/ }, () => {
       return {
         path: path.join(__dirname, '../node_modules/cbor-web/dist/cbor.js'),
+      };
+    });
+    build.onResolve({ filter: /^stream$/ }, () => {
+      return {
+        path: path.join(
+          __dirname,
+          '../node_modules/stream-browserify/index.js'
+        ),
       };
     });
   },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "formik": "^2.2.6",
     "fs-extra": "^9.1.0",
     "html-webpack-plugin": "5.3.1",
+    "https-browserify": "^1.0.0",
     "i18next": "^19.9.2",
     "i18next-http-backend": "^1.1.1",
     "identity-obj-proxy": "3.0.0",
@@ -67,6 +68,7 @@
     "optimize-css-assets-webpack-plugin": "5.0.4",
     "orbit-db-feedstore": "^1.12.0",
     "orbit-db-kvstore": "^1.12.0",
+    "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.1",
     "pnp-webpack-plugin": "1.6.4",
     "polished": "^4.1.1",
@@ -95,6 +97,7 @@
     "semver": "7.3.4",
     "simple-peer": "^9.9.3",
     "stream-browserify": "^3.0.0",
+    "stream-http": "^3.2.0",
     "style-loader": "2.0.0",
     "styled-components": "^5.2.1",
     "styled-normalize": "^8.0.7",
@@ -189,7 +192,9 @@
     "crypto": "crypto-browserify",
     "stream": "stream-browserify",
     "path": "path-browserify",
-    "cbor": "path-browserify"
+    "os": "os-browserify/browser",
+    "http": "stream-http",
+    "https": "https-browserify"
   },
   "scripts": {
     "start": "run-p watch:app watch:sw",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19887,6 +19887,16 @@ stream-http@^2.7.2:
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
 
+stream-http@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-3.2.0.tgz#1872dfcf24cb15752677e40e5c3f9cc1926028b5"
+  integrity sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==
+  dependencies:
+    builtin-status-codes "^3.0.0"
+    inherits "^2.0.4"
+    readable-stream "^3.6.0"
+    xtend "^4.0.2"
+
 stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"


### PR DESCRIPTION
We can see fallback packages that using in webpack.
I also use these packages.

https://github.com/webpack/webpack/blob/4837c3ddb9da8e676c73d97460e19689dd9d4691/lib/ModuleNotFoundError.js#L13-L42

